### PR TITLE
This commit introduces two changes to support external API integrations:

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -54,6 +54,7 @@ where
             "/tracker/{tracker_id}/dashboard_override",
             put(tracker::put_tracker_dashboard_override),
         )
+        .route("/user/self", get(user::get_self))
         .route("/user/self/api_key", get(user::get_api_key))
         .route("/user/self/api_key", post(user::reset_api_key))
         .route("/user/self/api_key", delete(user::clear_api_key))

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -125,3 +125,20 @@ where
 
     Ok(Json(UserSettings::from(user)))
 }
+
+// Define the response structure to expose the ID securely
+#[derive(Serialize)]
+pub struct UserProfile {
+    pub id: i32,
+    pub discord_username: String,
+}
+
+/// `GET /user/self`: Get current user details.
+pub async fn get_self(
+    auth_user: crate::auth::token::AuthenticatedUser
+) -> impl IntoResponse {
+    Json(UserProfile {
+        id: auth_user.user.id,
+        discord_username: auth_user.user.discord_username,
+    })
+}


### PR DESCRIPTION
1. Added `GET /user/self`:
   - Returns the authenticated user's ID and Discord username.
   - Essential for API-key-based integrations to identify the `ct_user_id` without relying on fragile name matching or write-events.

2. Added `user_id` query parameter to `GET /tracker/{tracker_id}`:
   - Allows clients to request only the slots claimed by a specific user.
   - Significantly reduces JSON payload size and network latency for large trackers (e.g., 1000+ location Multiworlds) when the client only needs user-specific data.
   - Logic is implemented via in-place vector filtering to minimize memory overhead.